### PR TITLE
Minor recipe updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @marcelotrevisani @ngam
+* @anthchirp @marcelotrevisani @ngam

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@anthchirp](https://github.com/anthchirp/)
 * [@marcelotrevisani](https://github.com/marcelotrevisani/)
 * [@ngam](https://github.com/ngam/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,6 @@ requirements:
     - typed-ast >=1.5.0  # [py<38]
 
 test:
-  requires:
-    - pip
   imports:
     - pytype
     - pytype.overlays
@@ -65,7 +63,6 @@ test:
     - pytype --help
     - pytype-single --help
     - pyxref --help
-    - pip check
 
 about:
   home: https://google.github.io/pytype/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,8 @@ source:
     folder: typeshed
 
 build:
-  number: 0
-  skip: true  # [py<36 or py>=310 or win]
+  number: 1
+  skip: true  # [py>=310 or win]
   # no windows builds here: https://pypi.org/project/pytype/#files
   entry_points:
     - annotate-ast = pytype.tools.annotate_ast.main:main
@@ -44,14 +44,13 @@ requirements:
     - python
   run:
     - attrs >=21.2.0
-    - dataclasses
-    - importlab >=0.6.1
-    - ninja >=1.10.0
+    - importlab >=0.7
+    - libcst
+    - ninja >=1.10.0.post2
+    - python
     - tabulate
     - toml
-    - typed-ast >=1.5.0
-    - libcst
-    - python
+    - typed-ast >=1.5.0  # [py<38]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,3 +74,4 @@ extra:
   recipe-maintainers:
     - ngam
     - marcelotrevisani
+    - anthchirp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,8 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   imports:
     - pytype
     - pytype.overlays
@@ -64,6 +66,7 @@ test:
     - pytype --help
     - pytype-single --help
     - pyxref --help
+    - pip check
 
 about:
   home: https://google.github.io/pytype/


### PR DESCRIPTION
I noted that `pip check` fails downstream of a pytype installation. Turns out that the `pytype` package is not to blame, but here are a couple of recipe updates anyway:

* Add 'pip check' to tests
* There are no Python <=3.6 builds any more
* Drop the now no-op dataclasses dependency
* Sync remaining dependencies with upstream

Haven't rerendered yet, as this PR is currently blocked by https://github.com/conda-forge/ninja-feedstock/issues/26 anyway

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
