### PR TITLE
added test of full command line use.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,8 @@ test:
   imports:
     - pytype
     - pytype.overlays
+  files:
+    - run_pytype.py
   commands:
     - annotate-ast --help
     - merge-pyi --help
@@ -66,6 +68,7 @@ test:
     - pytype --help
     - pytype-single --help
     - pyxref --help
+    - python run_pytype.py # checks that pytype can actually run with a file input.
     # enable after https://github.com/conda-forge/staged-recipes/pull/19098
     # - pip check
   requires:

--- a/recipe/run_pytype.py
+++ b/recipe/run_pytype.py
@@ -1,0 +1,44 @@
+"""
+A short script to run pytype with a real file to check
+
+This should catch whether you can actually run pytype
+
+(in particular if pytypw works with the conda-installed ninja)
+
+NOTE: I suppose it would be more robust to see if it actually
+      does the check correctly, but that's really pytype's problem
+"""
+import sys
+import subprocess
+from pathlib import Path
+
+TEST_FILE = """
+
+def fun(x: int):
+    return x * 2
+
+# this should type check with no errors
+y = fun(2)
+
+# this should type check with an error
+# z = fun(2.0)
+"""
+
+filepath = Path("python_test_file.py")
+
+with open(filepath, 'w', encoding='utf-8') as pyfile:
+    pyfile.write(TEST_FILE)
+
+try:
+    subprocess.check_call(("pytype", str(filepath)))
+    # it worked
+    sys.exit(0)
+except subprocess.CalledProcessError:
+    # something went wrong
+    print("Something went wrong running pytype")
+    raise
+finally:
+    filepath.unlink(missing_ok=False)
+
+
+


### PR DESCRIPTION

Due to the issue with pytype packages being broken for ages -- thanks to the ninja python wrapper, I thought it would be handy to have a test in the recipe that tests if you can actually run pytype.

So here it is -- It's failing now, which is the point. I *think( it will pass if the issue gets resolved upstream -- but we'll see, it's hard to test that.

